### PR TITLE
Add gatsby-starter-calpa-blog in starters

### DIFF
--- a/docs/starters.yml
+++ b/docs/starters.yml
@@ -1,3 +1,23 @@
+- url: https://calpa.me/
+  repo: https://github.com/calpa/gatsby-starter-calpa-blog
+  description: Blog Template X Contentful, Twitter and Facebook style
+  tags:
+    - Blog
+    - Tags
+  features:
+    - GatsbyJS v2, faster than faster
+    - Not just Contentful content source, you can use any database
+    - Custom style
+    - Google Analytics
+    - Gitalk
+    - sitemap
+    - React FontAwesome 
+    - SEO
+    - Offline support
+    - Web App Manifest
+    - Styled using SCSS
+    - Page pagination
+    - Netlify optimization
 - url: https://wonism.github.io/
   repo: https://github.com/wonism/gatsby-advanced-blog
   description: n/a


### PR DESCRIPTION
I have turned my blog from static bundled project to a starter project, and it may suitable for those using contentful, or facebook-twitter fans. 👍 

Please use master branch, and this starter is using v2.

Starter repo: https://github.com/calpa/gatsby-starter-calpa-blog
Demo site (in Chinese): https://calpa.me

<!--
  Q. Which branch should I use for my pull request?
  A. Use `master` branch (probably).

  Q. Which branch if my change is a bug fix for Gatsby v1?
  A. In this case, you should use the `v1` branch

  Q. Which branch if I'm still not sure?
  A. Use `master` branch. Ask in the PR if you're not sure and a Gatsby maintainer will be happy to help :)

  Note: We will only accept bug fixes for Gatsby v1. New features should be added to Gatsby v2.

  Learn more about contributing: https://www.gatsbyjs.org/docs/how-to-contribute/
-->
